### PR TITLE
Make commands in help match configured key bindings

### DIFF
--- a/lib/rebase-file.js
+++ b/lib/rebase-file.js
@@ -1,19 +1,43 @@
 'use strict';
 
-const editorCommands = [
-  '# NOTE: x is not supported by rebase editor',
-  '#',
-  '# Rebase Editor Commands:',
-  '# DOWN/UP = Moves cursor between lines',
-  '# SHIFT_RIGHT/SHIFT_DOWN = Select one line down',
-  '# SHIFT_LEFT/SHIFT_UP = Select one line up',
-  '# RIGHT/CTRL_DOWN = Moves current line down one position',
-  '# LEFT/CTRL_UP = Moves current line up one position',
-  '# z, CTRL_Z = Undo',
-  '# Z, CTRL_SHIFT_Z = Redo',
-  '# ENTER, q = Save and quit',
-  '# ESC, CTRL_C = Abort'
-];
+function getKeyInfo(action, keyBindings, description) {
+  let keys = [];
+  Object.keys(keyBindings).forEach((key) => {
+    if (keyBindings[key] === action) {
+      keys.push(key);
+    }
+  });
+
+  return '# ' + keys.join(', ') + ' = ' + description;
+}
+
+const actionDescriptions = {
+  'up': 'Moves cursor up',
+  'down': 'Moves cursor down',
+  'selectDown': 'Select one line down',
+  'selectUp': 'Select one line up',
+  'moveDown': 'Moves current line down one position',
+  'moveUp': 'Moves current line up one position',
+  'undo': 'Undo',
+  'redo': 'Redo',
+  'quit': 'Save and quit',
+  'abort': 'Abort'
+};
+
+function editorCommands(keyBindings) {
+  let extraInfo = [
+    '# NOTE: x is not supported by rebase editor',
+    '#',
+    '# Rebase Editor Commands:',
+  ];
+
+  Object.keys(actionDescriptions).forEach((action) => {
+    extraInfo.push(getKeyInfo(action, keyBindings,
+      actionDescriptions[action]));
+  });
+
+  return extraInfo;
+}
 
 function toState(data) {
   let readingCommits = true;

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -99,11 +99,12 @@ module.exports = class Terminal {
     });
     allLines.push('');
     let emptyLines = 0;
+    let extraInfo = state.extraInfo && state.extraInfo(this.opts.keyBindings);
     state.info.forEach((line) => {
-      if (line === '#' && state.extraInfo) {
+      if (line === '#' && extraInfo) {
         emptyLines++;
         if (emptyLines === 2) {
-          state.extraInfo.forEach((line) => {
+          extraInfo.forEach((line) => {
             allLines.push(line);
           });
         }

--- a/test/rebase-file.spec.js
+++ b/test/rebase-file.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const rebaseFile = require('../lib/rebase-file');
+const keyBindings = require('../lib/key-bindings');
 
 function trim(str) {
   return str.trim().split('\n').map((line) => line.trim()).join('\n');
@@ -46,6 +47,26 @@ describe('Rebase file', function () {
       expect(rebaseFile.toFile(state)).to.equal(file);
       expect(state.lines[0].action).to.equal('# pick');
     });
+
+    it('should print key bindings as help', function () {
+      const state = rebaseFile.toState('pick ad3d434 Hello message');
+      expect(state.extraInfo(keyBindings())).to.deep.equal([
+        '# NOTE: x is not supported by rebase editor',
+        '#',
+        '# Rebase Editor Commands:',
+        '# UP = Moves cursor up',
+        '# DOWN = Moves cursor down',
+        '# SHIFT_DOWN, SHIFT_RIGHT = Select one line down',
+        '# SHIFT_UP, SHIFT_LEFT = Select one line up',
+        '# RIGHT, CTRL_DOWN = Moves current line down one position',
+        '# LEFT, CTRL_UP = Moves current line up one position',
+        '# z, CTRL_Z = Undo',
+        '# Z, CTRL_SHIFT_Z = Redo',
+        '# q, ENTER = Save and quit',
+        '# CTRL_C, ESCAPE = Abort'
+      ]);
+    });
+
   });
 
   it('to file', function () {


### PR DESCRIPTION
Currently, the key bindings displayed in the help while editing are static. This commit just makes the text reflect the current key bindings if they have changed.