### PR TITLE
Add git-interactive-rebase-tool to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,6 @@ Contributions and comments are welcome, just make an issue and/or pull req.
 
 ## Credits
 Thanks to Node.js and the wonderful [terminal-kit project](https://github.com/cronvel/terminal-kit).
+
+## See also
+There is also [git-interactive-rebase-tool](https://github.com/MitMaro/git-interactive-rebase-tool), a similar tools written in Rust.


### PR DESCRIPTION
I think in Open Source something like "competitions" works different: It is more like learning from each other, so I think it would be nice to mention also the `git-interactive-rebase-tool`

Reclaimer: I am not associated to git-interactive-rebase-tool, just a user of it.

Thanks for the great `rebase-editor` tools!