### PR TITLE
feat: add fixup flag commands

### DIFF
--- a/lib/key-bindings.js
+++ b/lib/key-bindings.js
@@ -29,6 +29,8 @@ module.exports = function (customKeyBindingsFile) {
     e: 'edit',
     s: 'squash',
     f: 'fixup',
+    ALT_F: 'fixup -c',
+    CTRL_F: 'fixup -C',
     b: 'break',
     d: 'drop',
     BACKSPACE: 'drop',

--- a/lib/reducer.js
+++ b/lib/reducer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const actions = ['pick', 'fixup', 'squash', 'reword', 'edit', 'drop'];
+const actions = ['pick', 'fixup', 'fixup -c', 'fixup -C', 'squash', 'reword', 'edit', 'drop'];
 const [DOWN, UP] = [1, -1];
 
 function deepFreeze(obj) {

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -344,6 +344,24 @@ describe('Reducer', function () {
       expect(newState.otherStateVar).to.equal(state.otherStateVar);
     });
 
+    it("should change on fixup - alternate keybinds with flag", function () {
+      const state = getState(3, 1);
+      let newState = reduce(state, "fixup -C");
+      expect(newState.lines[0]).to.equal(state.lines[0]);
+      expect(newState.lines[1].action).to.equal("fixup -C");
+      expect(newState.lines[1].message).to.equal(state.lines[1].message);
+      expect(newState.lines[1]).not.to.equal(state.lines[1]);
+      expect(newState.lines[2]).to.equal(state.lines[2]);
+      expect(newState.otherStateVar).to.equal(state.otherStateVar);
+      newState = reduce(state, "fixup -c");
+      expect(newState.lines[0]).to.equal(state.lines[0]);
+      expect(newState.lines[1].action).to.equal("fixup -c");
+      expect(newState.lines[1].message).to.equal(state.lines[1].message);
+      expect(newState.lines[1]).not.to.equal(state.lines[1]);
+      expect(newState.lines[2]).to.equal(state.lines[2]);
+      expect(newState.otherStateVar).to.equal(state.otherStateVar);
+    });
+
     it('should change entire selection', function () {
       const state = getState([{
         action: 'pick',


### PR DESCRIPTION
This addition allows users to add the `-c` or `-C` flag to the `fixup` command by using the `ALT_F` and `CTRL_F` keybinds, respectively. 

References #37 